### PR TITLE
Update Firebase peer dependencies for v11 and v12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2024-12-19
+
+### Fixed
+- **Firebase Dependency Conflict**: Updated peer dependencies to support both Firebase v10 and v11 (`^10.0.0 || ^11.0.0`) to resolve ERESOLVE errors when using the latest Firebase version
+- **Firebase Admin SDK Compatibility**: Extended firebase-admin peer dependency to support v12 (`^11.0.0 || ^12.0.0`) for better forward compatibility
+
 ## [1.2.1] - 2024-12-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-rbac",
-  "version": "1.0.1",
+  "version": "1.2.2",
   "description": "A flexible, granular role-based access control library for TypeScript with NextAuth integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -75,8 +75,8 @@
     "next-auth": "^4.24.5"
   },
   "peerDependencies": {
-    "firebase": "^10.0.0",
-    "firebase-admin": "^11.0.0"
+    "firebase": "^10.0.0 || ^11.0.0",
+    "firebase-admin": "^11.0.0 || ^12.0.0"
   },
   "peerDependenciesMeta": {
     "firebase": {


### PR DESCRIPTION
Expanded firebase peer dependency to allow v10 and v11, and firebase-admin to allow v11 and v12. This resolves ERESOLVE errors with newer Firebase versions and improves forward compatibility. Updated package version to 1.2.2 and documented changes in CHANGELOG.md.